### PR TITLE
fix: Do not ignore unfixed in security scan

### DIFF
--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -73,7 +73,7 @@ jobs:
           format: "table"
           exit-code: "1"
           vuln-type: "os,library"
-          severity: "MEDIUM,HIGH,CRITICAL"
+          severity: "LOW,MEDIUM,HIGH,CRITICAL"
 
   create_issues:
     name: Create issues for failed jobs

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -72,7 +72,6 @@ jobs:
           image-ref: "${{ env.REPO_NAME }}:latest"
           format: "table"
           exit-code: "1"
-          ignore-unfixed: true
           vuln-type: "os,library"
           severity: "MEDIUM,HIGH,CRITICAL"
 

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -57,7 +57,7 @@ jobs:
         id: prepare-build-args
         run: |
           build_args='${{ inputs.docker-build-args }}'
-          build_args=$(echo $build_args | jq -r '.[] | "--build-arg " + .')
+          build_args=$(echo $build_args | jq -r '.[] | "--build-arg " + .' | xargs)
           echo "BUILD_ARGS=$build_args" >> $GITHUB_ENV
 
       - name: Build docker image


### PR DESCRIPTION
We should not skip unfixed CVE in the daily security scans because we must bring awareness to these issues. We might need to switch to using some other lib if it won't be fixed, but not ignore it.

Regarding there our PR scanning... I think we should also not skip them there, but we might need a configurable parameter to allow for ignoring unfixed CVEs if we have AEG approval to do so.

This change does not provide that configuration, but we can add that when we move the Docker action into a reusable workflow.