### PR TITLE
feat: Add new branch type to Github Workflow check for Infrastructure changes

### DIFF
--- a/.github/workflows/semantic-pull-request-title.yml
+++ b/.github/workflows/semantic-pull-request-title.yml
@@ -31,3 +31,4 @@ jobs:
             build
             ci
             upgrade
+            infra


### PR DESCRIPTION
I propose adding a new branch type for Infrastructure, which will allow Evan and I to manage our changes to the new app's infrastructure more effectively during releases.