### PR TITLE
feature: Add monorepo support for all CI actions

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -47,6 +47,7 @@ jobs:
           echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))')" >> $GITHUB_OUTPUT
 
   go-generate-diff:
+    if: ${{ needs.detect-modules.outputs.module-dir != '' }}
     name: Check for go generate changes
     needs: detect-modules
     runs-on: ubuntu-latest

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-modules
-        run: echo "modules=$(jq '[.packages | keys[] | ${{ inputs.working-directory }}]' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
+        run: echo "modules=$(jq --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
 
   go-generate-diff:
     name: Check for go generate changes

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -44,10 +44,9 @@ jobs:
       - id: set-modules
         # compares the go modules from `release-please-config.json` in each repo to the directories with git diffs
         run: >-
-          echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))')" >> $GITHUB_OUTPUT
+          echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))' | awk '{ print ($1 == "[]" ? "[./.]" : $1); }')" >> $GITHUB_OUTPUT
 
   go-generate-diff:
-    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Check for go generate changes
     needs: detect-modules
     runs-on: ubuntu-latest
@@ -80,7 +79,6 @@ jobs:
           fi
 
   tests-and-builds:
-    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Run tests and builds
     needs: detect-modules
     runs-on: ubuntu-latest
@@ -107,7 +105,6 @@ jobs:
         working-directory: ${{ matrix.module-dir }}
 
   govulncheck:
-    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Go Vulnerability Check
     needs: detect-modules
     runs-on: ubuntu-latest
@@ -124,7 +121,6 @@ jobs:
           work-dir: ${{ matrix.module-dir }}
 
   linter:
-    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Run golangci-lint
     needs: detect-modules
     runs-on: ubuntu-latest

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -44,7 +44,7 @@ jobs:
       - id: set-modules
         # compares the go modules from `release-please-config.json` in each repo to the directories with git diffs
         run: >-
-          echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))' | awk '{ print ($1 == "[]" ? "[./.]" : $1); }')" >> $GITHUB_OUTPUT
+          echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))' | awk '{ print ($1 == "[]" ? "[\"./.\"]" : $1); }')" >> $GITHUB_OUTPUT
 
   go-generate-diff:
     name: Check for go generate changes

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-modules
-        run: echo "module-dir=$(jq --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
+        run: echo "module-dir=$(jq -c --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
 
   go-generate-diff:
     name: Check for go generate changes

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -31,6 +31,9 @@ on:
         required: false
         type: boolean
         default: false
+env:
+  GO_VERSION: stable
+  GOLANGCI_LINT_VERSION: v1.60
 
 jobs:
   go-generate-diff:
@@ -96,12 +99,25 @@ jobs:
           go-package: ./...
           work-dir: ${{ inputs.working-directory }}
 
+  detect-modules:
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.set-modules.outputs.modules }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - id: set-modules
+        run: echo "modules=$(go list -m -json | jq -s '.' | jq -c '[.[].Dir]')" >> $GITHUB_OUTPUT # a json array of go modules in the repo
   linter:
+    needs: detect-modules
     name: Run golangci-lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
         build-tag: ${{ fromJson(inputs.build-tags) }}
+        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -109,18 +125,18 @@ jobs:
       - name: Set up Go for app
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ inputs.working-directory }}/go.mod
-          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+          go-version-file: ${{ matrix.modules }}/go.mod
+          cache-dependency-path: ${{ matrix.modules }}/go.sum
 
-      - name: golangci-lint
+      - name: golangci-lint ${{ matrix.modules }}
         uses: golangci/golangci-lint-action@v6
         with:
           # The version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: ${{ inputs.golangci-lint-version }}
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
 
           args: --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }}
 
           # Show only new issues if it's a pull request
           only-new-issues: ${{ inputs.golangci-lint-only-new-issues }}
 
-          working-directory: ${{ inputs.working-directory }}
+          working-directory: ${{ matrix.modules }} # if there is more than one module in the workspace they will all be linted

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -36,11 +36,11 @@ jobs:
   detect-modules:
     runs-on: ubuntu-latest
     outputs:
-      modules: ${{ steps.set-modules.outputs.modules }}
+      module-dir: ${{ steps.set-modules.outputs.module-dir }}
     steps:
       - uses: actions/checkout@v4
       - id: set-modules
-        run: echo "modules=$(jq --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
+        run: echo "module-dir=$(jq --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
 
   go-generate-diff:
     name: Check for go generate changes
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
+        module-dir: ${{ fromJson(needs.detect-modules.outputs.module-dir) }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -56,15 +56,15 @@ jobs:
       - name: Set up Go for app
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ matrix.modules }}/go.mod
-          cache-dependency-path: ${{ matrix.modules }}/go.sum
+          go-version-file: ${{ matrix.module-dir }}/go.mod
+          cache-dependency-path: ${{ matrix.module-dir }}/go.sum
 
       - name: Install mockgen
         run: go install go.uber.org/mock/mockgen@latest
 
       - name: Run go generate
         run: go generate ./...
-        working-directory: ${{ matrix.modules }}
+        working-directory: ${{ matrix.module-dir }}
 
       - name: Check for go generate changes
         run: |
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         build-tag: ${{ fromJson(inputs.build-tags) }}
-        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
+        module-dir: ${{ fromJson(needs.detect-modules.outputs.module-dir) }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -89,16 +89,16 @@ jobs:
       - name: Set up Go for app
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ matrix.modules }}/go.mod
-          cache-dependency-path: ${{ matrix.modules }}/go.sum
+          go-version-file: ${{ matrix.module-dir }}/go.mod
+          cache-dependency-path: ${{ matrix.module-dir }}/go.sum
 
       - name: Run tests with race detection
         run: go test ${{ matrix.build-tag != '' && format('-tags {0}', matrix.build-tag) || '' }} -v -race ./...
-        working-directory: ${{ matrix.modules }}
+        working-directory: ${{ matrix.module-dir }}
 
       - name: Run build
         run: go build ${{ matrix.build-tag != '' && format('-tags {0}', matrix.build-tag) || '' }}
-        working-directory: ${{ matrix.modules }}
+        working-directory: ${{ matrix.module-dir }}
 
   govulncheck:
     name: Go Vulnerability Check
@@ -106,15 +106,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
+        module-dir: ${{ fromJson(needs.detect-modules.outputs.module-dir) }}
     steps:
-      - name: govulncheck ${{ matrix.modules }}
+      - name: govulncheck ${{ matrix.module-dir }}
         # NOTE: Repo checkout and go setup are handled within 'govulncheck-action'
         uses: golang/govulncheck-action@v1
         with:
-          go-version-file: ${{ matrix.modules }}/go.mod
+          go-version-file: ${{ matrix.module-dir }}/go.mod
           go-package: ./...
-          work-dir: ${{ matrix.modules }}
+          work-dir: ${{ matrix.module-dir }}
 
   linter:
     name: Run golangci-lint
@@ -123,7 +123,7 @@ jobs:
     strategy:
       matrix:
         build-tag: ${{ fromJson(inputs.build-tags) }}
-        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
+        module-dir: ${{ fromJson(needs.detect-modules.outputs.module-dir) }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -131,10 +131,10 @@ jobs:
       - name: Set up Go for app
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ matrix.modules }}/go.mod
-          cache-dependency-path: ${{ matrix.modules }}/go.sum
+          go-version-file: ${{ matrix.module-dir }}/go.mod
+          cache-dependency-path: ${{ matrix.module-dir }}/go.sum
 
-      - name: golangci-lint ${{ matrix.modules }}
+      - name: golangci-lint ${{ matrix.module-dir }}
         uses: golangci/golangci-lint-action@v6
         with:
           # The version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
@@ -145,4 +145,4 @@ jobs:
           # Show only new issues if it's a pull request
           only-new-issues: ${{ inputs.golangci-lint-only-new-issues }}
 
-          working-directory: ${{ matrix.modules }} # if there is more than one module in the workspace they will all be linted
+          working-directory: ${{ matrix.module-dir }} # if there is more than one module in the workspace they will all be linted

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -80,6 +80,7 @@ jobs:
           fi
 
   tests-and-builds:
+    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Run tests and builds
     needs: detect-modules
     runs-on: ubuntu-latest
@@ -106,6 +107,7 @@ jobs:
         working-directory: ${{ matrix.module-dir }}
 
   govulncheck:
+    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Go Vulnerability Check
     needs: detect-modules
     runs-on: ubuntu-latest
@@ -122,6 +124,7 @@ jobs:
           work-dir: ${{ matrix.module-dir }}
 
   linter:
+    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Run golangci-lint
     needs: detect-modules
     runs-on: ubuntu-latest

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -47,7 +47,7 @@ jobs:
           echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))')" >> $GITHUB_OUTPUT
 
   go-generate-diff:
-    if: ${{ needs.detect-modules.outputs.module-dir != '' }}
+    if: ${{ needs.detect-modules.outputs.module-dir != '[]' }}
     name: Check for go generate changes
     needs: detect-modules
     runs-on: ubuntu-latest

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -39,6 +39,8 @@ jobs:
       module-dir: ${{ steps.set-modules.outputs.module-dir }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - id: set-modules
         # compares the go modules from `release-please-config.json` in each repo to the directories with git diffs
         run: >-

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -96,14 +96,19 @@ jobs:
 
   govulncheck:
     name: Go Vulnerability Check
+    needs: detect-modules
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
     steps:
-      # NOTE: Repo checkout and go setup are handled within 'govulncheck-action'
-      - uses: golang/govulncheck-action@v1
+      - name: govulncheck ${{ matrix.modules }}
+        # NOTE: Repo checkout and go setup are handled within 'govulncheck-action'
+        uses: golang/govulncheck-action@v1
         with:
-          go-version-file: ${{ inputs.working-directory }}/go.mod
+          go-version-file: ${{ matrix.modules }}/go.mod
           go-package: ./...
-          work-dir: ${{ inputs.working-directory }}
+          work-dir: ${{ matrix.modules }}
 
   linter:
     name: Run golangci-lint

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -31,11 +31,17 @@ on:
         required: false
         type: boolean
         default: false
-env:
-  GO_VERSION: stable
-  GOLANGCI_LINT_VERSION: v1.60
 
 jobs:
+  detect-modules:
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.set-modules.outputs.modules }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-modules
+        run: echo "modules=$(jq '[.packages | keys[] | ${{ inputs.working-directory }}]' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
+
   go-generate-diff:
     name: Check for go generate changes
     runs-on: ubuntu-latest
@@ -99,20 +105,9 @@ jobs:
           go-package: ./...
           work-dir: ${{ inputs.working-directory }}
 
-  detect-modules:
-    runs-on: ubuntu-latest
-    outputs:
-      modules: ${{ steps.set-modules.outputs.modules }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - id: set-modules
-        run: echo "modules=$(go list -m -json | jq -s '.' | jq -c '[.[].Dir]')" >> $GITHUB_OUTPUT # a json array of go modules in the repo
   linter:
-    needs: detect-modules
     name: Run golangci-lint
+    needs: detect-modules
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -132,7 +127,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # The version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          version: ${{ inputs.golangci-lint-version }}
 
           args: --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }}
 

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -44,7 +44,11 @@ jobs:
 
   go-generate-diff:
     name: Check for go generate changes
+    needs: detect-modules
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -52,15 +56,15 @@ jobs:
       - name: Set up Go for app
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ inputs.working-directory }}/go.mod
-          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+          go-version-file: ${{ matrix.modules }}/go.mod
+          cache-dependency-path: ${{ matrix.modules }}/go.sum
 
       - name: Install mockgen
         run: go install go.uber.org/mock/mockgen@latest
 
       - name: Run go generate
         run: go generate ./...
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ matrix.modules }}
 
       - name: Check for go generate changes
         run: |

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -72,10 +72,12 @@ jobs:
 
   tests-and-builds:
     name: Run tests and builds
+    needs: detect-modules
     runs-on: ubuntu-latest
     strategy:
       matrix:
         build-tag: ${{ fromJson(inputs.build-tags) }}
+        modules: ${{ fromJson(needs.detect-modules.outputs.modules) }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -83,16 +85,16 @@ jobs:
       - name: Set up Go for app
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ inputs.working-directory }}/go.mod
-          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+          go-version-file: ${{ matrix.modules }}/go.mod
+          cache-dependency-path: ${{ matrix.modules }}/go.sum
 
       - name: Run tests with race detection
         run: go test ${{ matrix.build-tag != '' && format('-tags {0}', matrix.build-tag) || '' }} -v -race ./...
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ matrix.modules }}
 
       - name: Run build
         run: go build ${{ matrix.build-tag != '' && format('-tags {0}', matrix.build-tag) || '' }}
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ matrix.modules }}
 
   govulncheck:
     name: Go Vulnerability Check

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -44,9 +44,7 @@ jobs:
       - id: set-modules
         # compares the go modules from `release-please-config.json` in each repo to the directories with git diffs
         run: >-
-          echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) \
-          --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') \
-          '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))')" >> $GITHUB_OUTPUT
+          echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))')" >> $GITHUB_OUTPUT
 
   go-generate-diff:
     name: Check for go generate changes

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -40,7 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-modules
-        run: echo "module-dir=$(jq -c --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json)" >> $GITHUB_OUTPUT # uses the `release-please-config.json` in each repo to retrieve go module(s)
+        # compares the go modules from `release-please-config.json` in each repo to the directories with git diffs
+        run: >-
+          echo "module-dir=$(jq -cnS --argjson packages $(jq -cS --arg workingDir ${{ inputs.working-directory }} '( ((.packages | keys?) // []) | if length == 0 then ["\($workingDir)"] else map("\($workingDir)/\(.)") end)' release-please-config.json) \
+          --argjson changed_dirs $(git diff --name-only --line-prefix='./' refs/remotes/origin/master HEAD | awk -F "/*[^/]*/*$" '{ print ($1 == "." ? "./." : $1); }' | cut -d "/" -f1-2 | sort | uniq | jq -ncRS '[inputs]') \
+          '$packages | map(select(. as $pkg | $changed_dirs | index($pkg)))')" >> $GITHUB_OUTPUT
 
   go-generate-diff:
     name: Check for go generate changes


### PR DESCRIPTION
Using the Go Workspace example from https://github.com/golangci/golangci-lint-action & the `release-please-config.json` we have in each repo

This adds support for linting submodules in a monorepo like `cccteam/ccc`.