### PR TITLE
upgrade: Update the security scan for changes to aquasecurity/trivy-action

### DIFF
--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -186,6 +186,7 @@ jobs:
           docker build $BUILD_ARGS -t $repo_name:latest .
 
       - name: Run Trivy vulnerability scanner (capture findings)
+        id: trivy_scan
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "${{ env.REPO_NAME }}:latest"
@@ -193,7 +194,8 @@ jobs:
           output: ${{ env.REPORT_PATH }}
           vuln-type: "os,library"
           severity: "LOW,MEDIUM,HIGH,CRITICAL"
-          table-mode: "detailed"
+          exit-code: "1"
+        continue-on-error: true
 
       - name: Save Trivy report as artifact
         uses: actions/upload-artifact@v4
@@ -201,20 +203,11 @@ jobs:
           name: ${{ env.REPORT_NAME }}
           path: ${{ env.REPORT_PATH }}
 
-      - name: Report findings
+      - name: Report failed Trivy scan
+        if: steps.trivy_scan.outcome == 'failure'
         run: |
-          FILE=${{ env.REPORT_PATH }}
-          if ! grep -qiE "Total: [1-9]" "$FILE"; then
-            if grep -qiE "Total: 0" "$FILE"; then
-              echo "No vulnerabilities found"
-              exit 0;
-            else
-              echo "failed to properly parse the trivy report!\nFailed to find a Total line\n"
-            fi
-          fi
-          cat ${{ env.REPORT_PATH }}
-          exit 1;
-        shell: bash
+          echo "Trivy scan failed. Refer to the Trivy report for additional details."
+          exit 1
 
   dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Report failed Trivy scan
         if: steps.trivy_scan.outcome == 'failure'
         run: |
-          echo "Trivy scan failed. Refer to the Trivy report for additional details."
+          cat ${{ env.REPORT_PATH }}
           exit 1
 
   dependabot:

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -193,6 +193,7 @@ jobs:
           output: ${{ env.REPORT_PATH }}
           vuln-type: "os,library"
           severity: "LOW,MEDIUM,HIGH,CRITICAL"
+          table-mode: "detailed"
 
       - name: Save Trivy report as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Trivy updated to include "summary mode" by default, which causes our grepper to fail because it previously had an empty output OR a total.

https://trivy.dev/v0.60/docs/configuration/reporting/#table-mode

Check out the Report options here:

https://trivy.dev/latest/docs/references/configuration/config-file/#report-options