### PR TITLE
ci: Fix apostrophe in commands description in Angular CI workflow

### DIFF
--- a/.github/workflows/angular-ci.yml
+++ b/.github/workflows/angular-ci.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: './gui'
       commands:
-        description: 'List of npm commands to run. These come from the "scripts" section in your project's package.json.'
+        description: 'List of npm commands to run. These come from the "scripts" section in your project''s package.json.'
         required: false
         type: string
         default: '["build", "lint"]'


### PR DESCRIPTION
Correct the apostrophe in the commands description to ensure clarity and accuracy in the documentation.