### PR TITLE
fix: filter TFLint SARIF results missing locations before upload

### DIFF
--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -42,11 +42,17 @@ jobs:
       - name: Run TFLint
         run: tflint --recursive --format=sarif --minimum-failure-severity=warning > tflint-results.sarif || true
 
-      - name: Upload TFLint SARIF file
+      - name: Filter TFLint SARIF results missing locations
         if: hashFiles('tflint-results.sarif') != ''
+        run: |
+          jq 'del(.runs[].results[] | select((.locations == null) or (.locations | length == 0)))' \
+            tflint-results.sarif > tflint-filtered.sarif
+
+      - name: Upload TFLint SARIF file
+        if: hashFiles('tflint-filtered.sarif') != ''
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
-          sarif_file: tflint-results.sarif
+          sarif_file: tflint-filtered.sarif
           category: tflint
 
   checkov-full-scan:


### PR DESCRIPTION
## Summary

- TFLint's recursive SARIF output can produce results with no `locations` field (e.g. module-level findings)
- GitHub Code Scanning rejects SARIF files containing results without at least one location, causing the upload step to fail with `locationFromSarifResult: expected at least one location`
- Adds a `jq` filter step to strip location-less results from the SARIF before uploading

## Test plan

- [ ] Trigger `terraform-security-scan` workflow manually on a repo that previously hit this error (e.g. `AscendiumEducationGroup/tf-ascendium-aws-modules`)
- [ ] Confirm TFLint SARIF upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)