### PR TITLE
feat: golang-ci sarif uploads + migrate GH app auth to use client id

### DIFF
--- a/.github/workflows/docker-build-and-scan.yml
+++ b/.github/workflows/docker-build-and-scan.yml
@@ -93,14 +93,12 @@ jobs:
           build_args=$(echo $build_args | jq -r '.[] | "--build-arg " + .' | xargs)
           echo "BUILD_ARGS=$build_args" >> $GITHUB_ENV
           dockerfile_safe=$(echo '${{ inputs.dockerfile }}' | sed 's/[^a-zA-Z0-9._-]/-/g')
-          echo "SBOM_ARTIFACT_NAME=sbom-${dockerfile_safe}" >> $GITHUB_ENV
           echo "sbom_artifact_name=sbom-${dockerfile_safe}" >> $GITHUB_OUTPUT
 
       - name: Build docker image
         id: build
         run: |
           repo_name=$(echo "${{ github.repository }}" | awk '{print tolower($0)}')
-          echo "REPO_NAME=$repo_name" >> $GITHUB_ENV
           echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
           docker build $BUILD_ARGS -t $repo_name:latest -f ${{ inputs.dockerfile }} .
 

--- a/.github/workflows/docker-build-and-scan.yml
+++ b/.github/workflows/docker-build-and-scan.yml
@@ -1,7 +1,6 @@
 # This reusable workflow can be used in repositories that include a Dockerfile to perform the following actions:
 #  - Lint the Docker file via 'hadolint'.
 #  - Build the Docker image.
-#  - Optionally scan the Docker image for vulnerabilities via the 'Trivy' scanner (disabled by default).
 #  - Optionally scan the Docker image for vulnerabilities via the 'Grype' scanner (disabled by default).
 #  - Optionally upload Grype scan results as a SARIF report to GitHub Advanced Security (disabled by default).
 #  - Optionally generate a Software Bill of Materials (SBOM) via 'Syft' (disabled by default).
@@ -23,26 +22,6 @@ on:
         type: string
         default: '[]' # empty array
         description: Json-formatted array of strings to pass to the docker build command as build args. e.g. '["arg1", "arg2"]'
-      execute-trivy-scan:
-        required: false
-        type: boolean
-        default: false
-        description: Execute Trivy vulnerability scanning of the Docker image
-      vuln-types:
-        required: false
-        type: string
-        default: 'os,library'
-        description: Comma-separated list of vulnerability types to scan for. e.g. 'os,library'
-      ignore-unfixed:
-        required: false
-        type: boolean
-        default: false
-        description: Ignore unfixed vulnerabilities
-      severity:
-        required: false
-        type: string
-        default: 'LOW,MEDIUM,HIGH,CRITICAL'
-        description: Comma-separated list of vulnerability severities to scan for. e.g. 'LOW,MEDIUM,HIGH,CRITICAL'
       execute-grype-scan:
         required: false
         type: boolean
@@ -115,30 +94,21 @@ jobs:
           echo "BUILD_ARGS=$build_args" >> $GITHUB_ENV
           dockerfile_safe=$(echo '${{ inputs.dockerfile }}' | sed 's/[^a-zA-Z0-9._-]/-/g')
           echo "SBOM_ARTIFACT_NAME=sbom-${dockerfile_safe}" >> $GITHUB_ENV
+          echo "sbom_artifact_name=sbom-${dockerfile_safe}" >> $GITHUB_OUTPUT
 
       - name: Build docker image
         id: build
         run: |
           repo_name=$(echo "${{ github.repository }}" | awk '{print tolower($0)}')
           echo "REPO_NAME=$repo_name" >> $GITHUB_ENV
+          echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
           docker build $BUILD_ARGS -t $repo_name:latest -f ${{ inputs.dockerfile }} .
-
-      - name: Run Trivy vulnerability scanner
-        if: ${{ inputs.execute-trivy-scan }}
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: '${{ env.REPO_NAME }}:latest'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: '${{ inputs.ignore-unfixed }}'
-          vuln-type: '${{ inputs.vuln-types }}'
-          severity: '${{ inputs.severity }}'
 
       - name: Run Grype vulnerability scanner
         if: ${{ inputs.execute-grype-scan && !inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image: '${{ env.REPO_NAME }}:latest'
+          image: '${{ steps.build.outputs.repo_name }}:latest'
           fail-build: 'true'
           severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
           output-format: 'table'
@@ -148,7 +118,7 @@ jobs:
         if: ${{ inputs.execute-grype-scan && inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image: '${{ env.REPO_NAME }}:latest'
+          image: '${{ steps.build.outputs.repo_name }}:latest'
           fail-build: 'false'
           severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
           output-format: 'sarif'
@@ -165,9 +135,9 @@ jobs:
         if: ${{ inputs.generate-sbom }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: '${{ env.REPO_NAME }}:latest'
+          image: '${{ steps.build.outputs.repo_name }}:latest'
           format: '${{ inputs.sbom-format }}'
-          artifact-name: '${{ env.SBOM_ARTIFACT_NAME }}'
+          artifact-name: '${{ steps.prepare-build-args.outputs.sbom_artifact_name }}'
           upload-artifact: true
 
       - name: Authenticate to GCP

--- a/.github/workflows/docker-build-and-scan.yml
+++ b/.github/workflows/docker-build-and-scan.yml
@@ -93,20 +93,19 @@ jobs:
           build_args=$(echo $build_args | jq -r '.[] | "--build-arg " + .' | xargs)
           echo "BUILD_ARGS=$build_args" >> $GITHUB_ENV
           dockerfile_safe=$(echo '${{ inputs.dockerfile }}' | sed 's/[^a-zA-Z0-9._-]/-/g')
-          echo "sbom_artifact_name=sbom-${dockerfile_safe}" >> $GITHUB_OUTPUT
+          echo "SBOM_ARTIFACT_NAME=sbom-${dockerfile_safe}" >> $GITHUB_ENV
 
       - name: Build docker image
-        id: build
         run: |
           repo_name=$(echo "${{ github.repository }}" | awk '{print tolower($0)}')
-          echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$repo_name" >> $GITHUB_ENV
           docker build $BUILD_ARGS -t $repo_name:latest -f ${{ inputs.dockerfile }} .
 
       - name: Run Grype vulnerability scanner
         if: ${{ inputs.execute-grype-scan && !inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image: '${{ steps.build.outputs.repo_name }}:latest'
+          image: '${{ env.REPO_NAME }}:latest'
           fail-build: 'true'
           severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
           output-format: 'table'
@@ -116,7 +115,7 @@ jobs:
         if: ${{ inputs.execute-grype-scan && inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image: '${{ steps.build.outputs.repo_name }}:latest'
+          image: '${{ env.REPO_NAME }}:latest'
           fail-build: 'false'
           severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
           output-format: 'sarif'
@@ -133,9 +132,9 @@ jobs:
         if: ${{ inputs.generate-sbom }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: '${{ steps.build.outputs.repo_name }}:latest'
+          image: '${{ env.REPO_NAME }}:latest'
           format: '${{ inputs.sbom-format }}'
-          artifact-name: '${{ steps.prepare-build-args.outputs.sbom_artifact_name }}'
+          artifact-name: '${{ env.SBOM_ARTIFACT_NAME }}'
           upload-artifact: true
 
       - name: Authenticate to GCP

--- a/.github/workflows/docker-build-and-scan.yml
+++ b/.github/workflows/docker-build-and-scan.yml
@@ -22,11 +22,6 @@ on:
         type: string
         default: '[]' # empty array
         description: Json-formatted array of strings to pass to the docker build command as build args. e.g. '["arg1", "arg2"]'
-      execute-trivy-scan:
-        required: false
-        type: boolean
-        default: false
-        description: '[DEPRECATED] Use execute-grype-scan. Kept for backward compatibility.'
       execute-grype-scan:
         required: false
         type: boolean
@@ -107,7 +102,7 @@ jobs:
           docker build $BUILD_ARGS -t $repo_name:latest -f ${{ inputs.dockerfile }} .
 
       - name: Run Grype vulnerability scanner
-        if: ${{ (inputs.execute-grype-scan || inputs.execute-trivy-scan) && !inputs.upload-sarif }}
+        if: ${{ inputs.execute-grype-scan && !inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           image: '${{ env.REPO_NAME }}:latest'
@@ -117,7 +112,7 @@ jobs:
 
       - name: Run Grype vulnerability scanner and generate SARIF
         id: grype-sarif
-        if: ${{ (inputs.execute-grype-scan || inputs.execute-trivy-scan) && inputs.upload-sarif }}
+        if: ${{ inputs.execute-grype-scan && inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           image: '${{ env.REPO_NAME }}:latest'
@@ -126,7 +121,7 @@ jobs:
           output-format: 'sarif'
 
       - name: Upload Grype SARIF report to GitHub Advanced Security Dashboard
-        if: ${{ (inputs.execute-grype-scan || inputs.execute-trivy-scan) && inputs.upload-sarif }}
+        if: ${{ inputs.execute-grype-scan && inputs.upload-sarif }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}

--- a/.github/workflows/docker-build-and-scan.yml
+++ b/.github/workflows/docker-build-and-scan.yml
@@ -22,6 +22,11 @@ on:
         type: string
         default: '[]' # empty array
         description: Json-formatted array of strings to pass to the docker build command as build args. e.g. '["arg1", "arg2"]'
+      execute-trivy-scan:
+        required: false
+        type: boolean
+        default: false
+        description: '[DEPRECATED] Use execute-grype-scan. Kept for backward compatibility.'
       execute-grype-scan:
         required: false
         type: boolean
@@ -102,7 +107,7 @@ jobs:
           docker build $BUILD_ARGS -t $repo_name:latest -f ${{ inputs.dockerfile }} .
 
       - name: Run Grype vulnerability scanner
-        if: ${{ inputs.execute-grype-scan && !inputs.upload-sarif }}
+        if: ${{ (inputs.execute-grype-scan || inputs.execute-trivy-scan) && !inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           image: '${{ env.REPO_NAME }}:latest'
@@ -112,7 +117,7 @@ jobs:
 
       - name: Run Grype vulnerability scanner and generate SARIF
         id: grype-sarif
-        if: ${{ inputs.execute-grype-scan && inputs.upload-sarif }}
+        if: ${{ (inputs.execute-grype-scan || inputs.execute-trivy-scan) && inputs.upload-sarif }}
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           image: '${{ env.REPO_NAME }}:latest'
@@ -121,7 +126,7 @@ jobs:
           output-format: 'sarif'
 
       - name: Upload Grype SARIF report to GitHub Advanced Security Dashboard
-        if: ${{ inputs.execute-grype-scan && inputs.upload-sarif }}
+        if: ${{ (inputs.execute-grype-scan || inputs.execute-trivy-scan) && inputs.upload-sarif }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -160,6 +160,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -170,7 +171,7 @@ jobs:
         run: echo "No changes detected in ${{ matrix.module-dir }}. Skipping vuln check."
 
       - name: govulncheck ${{ matrix.module-dir }}
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true }}
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && !inputs.upload-sarif }}
         # NOTE: Repo checkout and go setup are handled within 'govulncheck-action'
         # Pinned to master commit because a release has not been cut with the SHA-pinned dependencies fix
         uses: golang/govulncheck-action@3fa7bd9cee2cfdf3499a8803b226e43de7b7cdb4 # master 2026-02-28
@@ -180,6 +181,38 @@ jobs:
           go-version-file: ${{ matrix.module-dir }}/go.mod
           go-package: ./...
           work-dir: ${{ matrix.module-dir }}
+
+      - name: Checkout repository for SARIF run
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go for SARIF run
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: ${{ matrix.module-dir }}/go.mod
+          cache-dependency-path: ${{ matrix.module-dir }}/go.sum
+
+      - name: Install govulncheck for SARIF run
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck and generate SARIF
+        id: govulncheck-sarif
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
+        continue-on-error: true
+        run: govulncheck -format sarif -C ${{ matrix.module-dir }} ./... > ${{ matrix.module-dir }}/govulncheck.sarif
+
+      - name: Upload govulncheck SARIF file for GitHub Advanced Security Dashboard
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && hashFiles(format('{0}/govulncheck.sarif', matrix.module-dir)) != '' }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: ${{ matrix.module-dir }}/govulncheck.sarif
+          category: govulncheck-${{ matrix.module-dir }}
+
+      - name: Report failed govulncheck SARIF run
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && steps.govulncheck-sarif.outcome == 'failure' }}
+        run: exit 1
 
   semgrep-scan:
     name: Run Semgrep Scan
@@ -229,6 +262,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -251,7 +285,7 @@ jobs:
           cache-dependency-path: ${{ matrix.module-dir }}/go.sum
 
       - name: golangci-lint ${{ matrix.module-dir }}
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true }}
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && !inputs.upload-sarif }}
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: ${{ inputs.golangci-lint-version }}
@@ -259,3 +293,29 @@ jobs:
           # Show only new issues if it's a pull request
           only-new-issues: ${{ inputs.golangci-lint-only-new-issues }}
           working-directory: ${{ matrix.module-dir }}
+
+      - name: Install golangci-lint for SARIF run
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: ${{ inputs.golangci-lint-version }}
+          install-only: true
+          working-directory: ${{ matrix.module-dir }}
+
+      - name: Run golangci-lint and generate SARIF
+        id: golangci-lint-sarif
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
+        continue-on-error: true
+        run: golangci-lint run --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }} --out-format sarif ./... > ${{ matrix.module-dir }}/golangci-lint.sarif
+        working-directory: ${{ matrix.module-dir }}
+
+      - name: Upload golangci-lint SARIF file for GitHub Advanced Security Dashboard
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && hashFiles(format('{0}/golangci-lint.sarif', matrix.module-dir)) != '' }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: ${{ matrix.module-dir }}/golangci-lint.sarif
+          category: golangci-lint-${{ matrix.module-dir }}
+
+      - name: Report failed golangci-lint SARIF run
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && steps.golangci-lint-sarif.outcome == 'failure' }}
+        run: exit 1

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -182,9 +182,13 @@ jobs:
         run: echo "No changes detected in ${{ matrix.module-dir }}. Skipping vuln check."
 
       - name: govulncheck ${{ matrix.module-dir }}
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && !inputs.upload-sarif }}
+        id: govulncheck
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true }}
         # NOTE: Repo checkout and go setup are handled within 'govulncheck-action'
         # Pinned to master commit because a release has not been cut with the SHA-pinned dependencies fix
+        # continue-on-error so the SARIF upload step below still runs on vulnerability findings;
+        # the "Report failed" step re-fails the job afterward when upload-sarif is set.
+        continue-on-error: ${{ inputs.upload-sarif }}
         uses: golang/govulncheck-action@3fa7bd9cee2cfdf3499a8803b226e43de7b7cdb4 # master 2026-02-28
         with:
           # Explicitly unset this input so the action respects go-version-file instead.
@@ -192,27 +196,8 @@ jobs:
           go-version-file: ${{ matrix.module-dir }}/go.mod
           go-package: ./...
           work-dir: ${{ matrix.module-dir }}
-
-      - name: Checkout repository for SARIF run
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up Go for SARIF run
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: ${{ matrix.module-dir }}/go.mod
-          cache-dependency-path: ${{ matrix.module-dir }}/go.sum
-
-      - name: Install govulncheck for SARIF run
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
-      - name: Run govulncheck and generate SARIF
-        id: govulncheck-sarif
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
-        continue-on-error: true
-        run: govulncheck -format sarif -C ${{ matrix.module-dir }} ./... > ${{ matrix.module-dir }}/govulncheck.sarif
+          output-format: ${{ inputs.upload-sarif && 'sarif' || 'text' }}
+          output-file: ${{ inputs.upload-sarif && format('{0}/govulncheck.sarif', matrix.module-dir) || '' }}
 
       - name: Upload govulncheck SARIF file for GitHub Advanced Security Dashboard
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && hashFiles(format('{0}/govulncheck.sarif', matrix.module-dir)) != '' }}
@@ -222,7 +207,7 @@ jobs:
           category: govulncheck-${{ matrix.module-dir }}
 
       - name: Report failed govulncheck SARIF run
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && steps.govulncheck-sarif.outcome == 'failure' }}
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && steps.govulncheck.outcome == 'failure' }}
         run: exit 1
 
   semgrep-scan:

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -237,18 +237,27 @@ jobs:
       - name: Checkout repository
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Determine baseline commit
+        id: baseline
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true }}
+        # Diffs against the merge-base with master so only findings introduced by this branch are reported,
+        # instead of re-scanning the whole module on every run.
+        run: echo "sha=$(git merge-base refs/remotes/origin/master HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Perform Semgrep Analysis and Generate SARIF
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
         run: |
           cd ${{ matrix.module-dir }}
-          semgrep scan --config auto --sarif > semgrep.sarif
+          semgrep ci --config auto --baseline-commit=${{ steps.baseline.outputs.sha }} --sarif > semgrep.sarif
 
       - name: Perform Semgrep Analysis with CLI Output
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && !inputs.upload-sarif }}
         run: |
           cd ${{ matrix.module-dir }}
-          semgrep scan --config auto
+          semgrep ci --config auto --baseline-commit=${{ steps.baseline.outputs.sha }}
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -308,7 +308,7 @@ jobs:
         id: golangci-lint-sarif
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
         continue-on-error: true
-        run: golangci-lint run --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }} --out-format sarif ./... > ${{ matrix.module-dir }}/golangci-lint.sarif
+        run: golangci-lint run --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }} --output.sarif.path=golangci-lint.sarif ./...
         working-directory: ${{ matrix.module-dir }}
 
       - name: Upload golangci-lint SARIF file for GitHub Advanced Security Dashboard

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -161,6 +161,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -263,6 +264,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -306,29 +306,18 @@ jobs:
           cache-dependency-path: ${{ matrix.module-dir }}/go.sum
 
       - name: golangci-lint ${{ matrix.module-dir }}
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && !inputs.upload-sarif }}
+        id: golangci-lint
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true }}
+        # continue-on-error so the SARIF upload step below still runs on lint failures;
+        # the "Report failed" step re-fails the job afterward when upload-sarif is set.
+        continue-on-error: ${{ inputs.upload-sarif }}
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: ${{ inputs.golangci-lint-version }}
-          args: --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }}
+          args: --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }} ${{ inputs.upload-sarif && '--output.sarif.path=golangci-lint.sarif' || '' }}
           # Show only new issues if it's a pull request
           only-new-issues: ${{ inputs.golangci-lint-only-new-issues }}
           working-directory: ${{ matrix.module-dir }}
-
-      - name: Install golangci-lint for SARIF run
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        with:
-          version: ${{ inputs.golangci-lint-version }}
-          install-only: true
-          working-directory: ${{ matrix.module-dir }}
-
-      - name: Run golangci-lint and generate SARIF
-        id: golangci-lint-sarif
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
-        continue-on-error: true
-        run: golangci-lint run --timeout ${{ inputs.golangci-lint-timeout }} --verbose ${{ matrix.build-tag != '' && format('--build-tags {0}', matrix.build-tag) || '' }} --output.sarif.path=golangci-lint.sarif ./...
-        working-directory: ${{ matrix.module-dir }}
 
       - name: Upload golangci-lint SARIF file for GitHub Advanced Security Dashboard
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && hashFiles(format('{0}/golangci-lint.sarif', matrix.module-dir)) != '' }}
@@ -338,5 +327,5 @@ jobs:
           category: golangci-lint-${{ matrix.module-dir }}
 
       - name: Report failed golangci-lint SARIF run
-        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && steps.golangci-lint-sarif.outcome == 'failure' }}
+        if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif && steps.golangci-lint.outcome == 'failure' }}
         run: exit 1

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -40,6 +40,16 @@ on:
         type: boolean
         default: false
         description: 'Upload SARIF report for GitHub Advanced Security Dashboard'
+      semgrep-config:
+        required: false
+        type: string
+        default: 'auto'
+        description: 'Semgrep configuration to use (auto, p/security-audit, p/owasp-top-ten, etc.)'
+      semgrep-max-target-bytes:
+        required: false
+        type: number
+        default: 500000
+        description: 'Skip scanning files larger than this size (in bytes)'
       runs-on:
         required: false
         type: string
@@ -251,13 +261,13 @@ jobs:
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}
         run: |
           cd ${{ matrix.module-dir }}
-          semgrep ci --config auto --baseline-commit=${{ steps.baseline.outputs.sha }} --sarif > semgrep.sarif
+          semgrep ci --config ${{ inputs.semgrep-config }} --baseline-commit=${{ steps.baseline.outputs.sha }} --max-target-bytes ${{ inputs.semgrep-max-target-bytes }} --sarif > semgrep.sarif
 
       - name: Perform Semgrep Analysis with CLI Output
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && !inputs.upload-sarif }}
         run: |
           cd ${{ matrix.module-dir }}
-          semgrep ci --config auto --baseline-commit=${{ steps.baseline.outputs.sha }}
+          semgrep ci --config ${{ inputs.semgrep-config }} --baseline-commit=${{ steps.baseline.outputs.sha }} --max-target-bytes ${{ inputs.semgrep-max-target-bytes }}
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: ${{ fromJson(needs.detect-modules.outputs.has-changes)[matrix.module-dir] == true && inputs.upload-sarif }}

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -293,6 +293,7 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -74,7 +74,6 @@ on:
         description: >
           Path to a json file that contains a JSON array of Dependabot alerts to ignore.
           If not provided, no alerts will be ignored.
-
           Note: These alerts should be copied directly from the Dependabot issue so that the formatting is as expected.
       upload-sarif:
         required: false
@@ -91,7 +90,6 @@ on:
         type: number
         default: 500000
         description: 'Skip scanning files larger than this size (in bytes)'
-
       runs-on:
         required: false
         type: string

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -20,11 +20,6 @@ on:
         type: string
         default: 'latest'
         description: Version of govulncheck to use
-      execute-trivy-scan:
-        required: false
-        type: boolean
-        default: false
-        description: '[DEPRECATED] Use execute-grype-scan. Kept for backward compatibility.'
       execute-grype-scan:
         required: false
         type: boolean
@@ -291,7 +286,7 @@ jobs:
     needs: env-setup
     name: Grype Scan
     runs-on: ${{ inputs.runs-on }}
-    if: ${{ inputs.execute-grype-scan || inputs.execute-trivy-scan }}
+    if: ${{ inputs.execute-grype-scan }}
     permissions:
       security-events: write
       contents: read
@@ -585,7 +580,7 @@ jobs:
         continue-on-error: true # Continue if the artifact is not found
 
       - name: Download grype issue artifact
-        if: (inputs.execute-grype-scan || inputs.execute-trivy-scan) && needs.grype.result == 'failure'
+        if: inputs.execute-grype-scan && needs.grype.result == 'failure'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: grype-issue

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -163,11 +163,10 @@ jobs:
         module: ${{ fromJson(needs.detect-modules.outputs.modules) }}
     steps:
       - name: Set report variables
-        id: set-report-vars
         run: |
           SAFE_MODULE_NAME=$(echo "${{ matrix.module.name }}" | sed 's|[./]|-|g')
-          echo "report_name=govulncheck-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME" >> $GITHUB_OUTPUT
-          echo "report_path=govulncheck-report-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME.txt" >> $GITHUB_OUTPUT
+          echo "REPORT_NAME=govulncheck-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME" >> $GITHUB_ENV
+          echo "REPORT_PATH=govulncheck-report-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME.txt" >> $GITHUB_ENV
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -188,7 +187,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e # Ensure the script does not exit immediately on error
-          govulncheck -C ${{ matrix.module.dir }} ./... > ${{ steps.set-report-vars.outputs.report_path }}
+          govulncheck -C ${{ matrix.module.dir }} ./... > ${{ env.REPORT_PATH }}
           GOVULNCHECK_STATUS=$?
           if [ $GOVULNCHECK_STATUS -ne 0 ]; then
             touch vulnerabilities-found
@@ -198,13 +197,13 @@ jobs:
       - name: Save govulncheck report as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.set-report-vars.outputs.report_name }}
-          path: ${{ steps.set-report-vars.outputs.report_path }}
+          name: ${{ env.REPORT_NAME }}
+          path: ${{ env.REPORT_PATH }}
 
       - name: Report findings
         run: |
           if [[ -f vulnerabilities-found ]]; then
-            cat ${{ steps.set-report-vars.outputs.report_path }}
+            cat ${{ env.REPORT_PATH }}
             exit 1;
           else
             echo "No vulnerabilities found"
@@ -300,10 +299,9 @@ jobs:
         checkout-ref: ${{ fromJson(needs.env-setup.outputs.checkout-refs) }}
     steps:
       - name: Set report variables
-        id: set-report-vars
         run: |
-          echo "report_name=grype-${{ matrix.checkout-ref == '' && '1' || '2' }}" >> $GITHUB_OUTPUT
-          echo "report_path=grype-report-${{ matrix.checkout-ref == '' && '1' || '2' }}.txt" >> $GITHUB_OUTPUT
+          echo "REPORT_NAME=grype-${{ matrix.checkout-ref == '' && '1' || '2' }}" >> $GITHUB_ENV
+          echo "REPORT_PATH=grype-report-${{ matrix.checkout-ref == '' && '1' || '2' }}.txt" >> $GITHUB_ENV
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -346,7 +344,7 @@ jobs:
           fail-build: 'true'
           severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
           output-format: 'table'
-          output-file: '${{ steps.set-report-vars.outputs.report_path }}'
+          output-file: '${{ env.REPORT_PATH }}'
         continue-on-error: true
 
       - name: Run Grype SARIF scan
@@ -369,13 +367,13 @@ jobs:
       - name: Save Grype report as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.set-report-vars.outputs.report_name }}
-          path: ${{ steps.set-report-vars.outputs.report_path }}
+          name: ${{ env.REPORT_NAME }}
+          path: ${{ env.REPORT_PATH }}
 
       - name: Report failed Grype scan
         if: steps.grype_scan.outcome == 'failure'
         run: |
-          cat ${{ steps.set-report-vars.outputs.report_path }}
+          cat ${{ env.REPORT_PATH }}
           exit 1
 
   dependabot:
@@ -598,7 +596,6 @@ jobs:
         continue-on-error: true # Continue if the artifact is not found
 
       - name: Prepare Slack message
-        id: prepare_message
         run: |
           MESSAGE="URGENT! The security scan failed for the *${{ github.repository }}* repository. Check the logs at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ -f govulncheck-issue.txt ]; then
@@ -613,9 +610,9 @@ jobs:
             MESSAGE="$MESSAGE
             - $(cat dependabot-issue.txt)"
           fi
-          echo 'slack_message<<EOF' >> $GITHUB_OUTPUT
-          echo "$MESSAGE" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo 'SLACK_MESSAGE<<EOF' >> $GITHUB_ENV
+          echo "$MESSAGE" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
 
       - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
@@ -623,4 +620,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ inputs.slack-channel-id || secrets.SLACK_CHANNEL_ID }}
-            text: ${{ toJSON(steps.prepare_message.outputs.slack_message) }}
+            text: ${{ toJSON(env.SLACK_MESSAGE) }}

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -1,6 +1,6 @@
 # This workflow performs security scanning for Go projects.
 #  - govulncheck is used to check for vulnerabilities in the Go modules
-#  - trivy-action is used to check for vulnerabilities in the application's final docker image (optional, disabled by default)
+#  - grype is used to check for vulnerabilities in the application's final docker image (optional, disabled by default)
 #  - Dependabot security alerts are checked using the GitHub API
 # GitHub issues are created for failed jobs.
 # A Slack message is sent (per user provided details) if either security check fails.
@@ -24,7 +24,17 @@ on:
         required: false
         type: boolean
         default: false
-        description: Execute Trivy vulnerability scanning of the Docker image
+        description: '[DEPRECATED] Use execute-grype-scan. Kept for backward compatibility.'
+      execute-grype-scan:
+        required: false
+        type: boolean
+        default: false
+        description: Execute Grype vulnerability scanning of the Docker image
+      grype-fail-on-severity:
+        required: false
+        type: string
+        default: 'high'
+        description: Minimum vulnerability severity that causes Grype to fail the build (negligible, low, medium, high, critical)
 
       execute-dependabot-check:
         required: false
@@ -71,7 +81,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: 'Upload SARIF report for GitHub Advanced Security Dashboard'
+        description: 'Upload SARIF reports (where supported) for GitHub Advanced Security Dashboard'
       semgrep-config:
         required: false
         type: string
@@ -153,10 +163,11 @@ jobs:
         module: ${{ fromJson(needs.detect-modules.outputs.modules) }}
     steps:
       - name: Set report variables
+        id: set-report-vars
         run: |
           SAFE_MODULE_NAME=$(echo "${{ matrix.module.name }}" | sed 's|[./]|-|g')
-          echo "REPORT_NAME=govulncheck-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME" >> $GITHUB_ENV
-          echo "REPORT_PATH=govulncheck-report-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME.txt" >> $GITHUB_ENV
+          echo "report_name=govulncheck-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME" >> $GITHUB_OUTPUT
+          echo "report_path=govulncheck-report-${{ matrix.checkout-ref == '' && '1' || '2' }}-$SAFE_MODULE_NAME.txt" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -177,7 +188,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e # Ensure the script does not exit immediately on error
-          govulncheck -C ${{ matrix.module.dir }} ./... > ${{ env.REPORT_PATH }}
+          govulncheck -C ${{ matrix.module.dir }} ./... > ${{ steps.set-report-vars.outputs.report_path }}
           GOVULNCHECK_STATUS=$?
           if [ $GOVULNCHECK_STATUS -ne 0 ]; then
             touch vulnerabilities-found
@@ -187,13 +198,13 @@ jobs:
       - name: Save govulncheck report as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.REPORT_NAME }}
-          path: ${{ env.REPORT_PATH }}
+          name: ${{ steps.set-report-vars.outputs.report_name }}
+          path: ${{ steps.set-report-vars.outputs.report_path }}
 
       - name: Report findings
         run: |
           if [[ -f vulnerabilities-found ]]; then
-            cat ${{ env.REPORT_PATH }}
+            cat ${{ steps.set-report-vars.outputs.report_path }}
             exit 1;
           else
             echo "No vulnerabilities found"
@@ -275,12 +286,13 @@ jobs:
           sarif_file: semgrep.sarif
           category: semgrep
 
-  trivy:
+  grype:
     needs: env-setup
-    name: Trivy Scan
+    name: Grype Scan
     runs-on: ${{ inputs.runs-on }}
-    if: ${{ inputs.execute-trivy-scan }}
+    if: ${{ inputs.execute-grype-scan || inputs.execute-trivy-scan }}
     permissions:
+      security-events: write
       contents: read
     strategy:
       fail-fast: false
@@ -288,9 +300,10 @@ jobs:
         checkout-ref: ${{ fromJson(needs.env-setup.outputs.checkout-refs) }}
     steps:
       - name: Set report variables
+        id: set-report-vars
         run: |
-          echo "REPORT_NAME=trivy-${{ matrix.checkout-ref == '' && '1' || '2' }}" >> $GITHUB_ENV
-          echo "REPORT_PATH=trivy-report-${{ matrix.checkout-ref == '' && '1' || '2' }}.txt" >> $GITHUB_ENV
+          echo "report_name=grype-${{ matrix.checkout-ref == '' && '1' || '2' }}" >> $GITHUB_OUTPUT
+          echo "report_path=grype-report-${{ matrix.checkout-ref == '' && '1' || '2' }}.txt" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -305,9 +318,10 @@ jobs:
           echo "BUILD_ARGS=$build_args" >> $GITHUB_ENV
 
       - name: Build docker image
+        id: build-image
         run: |
           repo_name=$(echo "${{ github.repository }}" | awk '{print tolower($0)}')
-          echo "REPO_NAME=$repo_name" >> $GITHUB_ENV
+          echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
 
           docker_files="${{ inputs.docker-build-files }}"
           # Trim the '[]' and '"' characters from the array
@@ -325,28 +339,44 @@ jobs:
             docker build $BUILD_ARGS -t $repo_name:latest .
           fi
 
-      - name: Run Trivy vulnerability scanner (capture findings)
-        id: trivy_scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - name: Run Grype vulnerability scanner (capture findings)
+        id: grype_scan
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image-ref: '${{ env.REPO_NAME }}:latest'
-          format: 'table'
-          output: ${{ env.REPORT_PATH }}
-          vuln-type: 'os,library'
-          severity: 'LOW,MEDIUM,HIGH,CRITICAL'
-          exit-code: '1'
+          image: '${{ steps.build-image.outputs.repo_name }}:latest'
+          fail-build: 'true'
+          severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
+          output-format: 'table'
+          output-file: '${{ steps.set-report-vars.outputs.report_path }}'
         continue-on-error: true
 
-      - name: Save Trivy report as artifact
+      - name: Run Grype SARIF scan
+        id: grype_sarif
+        if: inputs.upload-sarif
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        with:
+          image: '${{ steps.build-image.outputs.repo_name }}:latest'
+          fail-build: 'false'
+          severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
+          output-format: 'sarif'
+
+      - name: Upload Grype SARIF file for GitHub Advanced Security Dashboard
+        if: inputs.upload-sarif
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: ${{ steps.grype_sarif.outputs.sarif }}
+          category: grype
+
+      - name: Save Grype report as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.REPORT_NAME }}
-          path: ${{ env.REPORT_PATH }}
+          name: ${{ steps.set-report-vars.outputs.report_name }}
+          path: ${{ steps.set-report-vars.outputs.report_path }}
 
-      - name: Report failed Trivy scan
-        if: steps.trivy_scan.outcome == 'failure'
+      - name: Report failed Grype scan
+        if: steps.grype_scan.outcome == 'failure'
         run: |
-          cat ${{ env.REPORT_PATH }}
+          cat ${{ steps.set-report-vars.outputs.report_path }}
           exit 1
 
   dependabot:
@@ -418,8 +448,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        label: [govulncheck, trivy, dependabot]
-    needs: [govulncheck, trivy, dependabot, merge-govulncheck-reports]
+        label: [govulncheck, grype, dependabot]
+    needs: [govulncheck, grype, dependabot, merge-govulncheck-reports]
     if: always()
     steps:
       - name: Setup environment for this matrix job
@@ -427,7 +457,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ needs.govulncheck.result }}" == "failure" && "${{ matrix.label }}" == "govulncheck" ]] || \
-           [[ "${{ needs.trivy.result }}" == "failure" && "${{ matrix.label }}" == "trivy" ]] || \
+           [[ "${{ needs.grype.result }}" == "failure" && "${{ matrix.label }}" == "grype" ]] || \
            [[ "${{ needs.dependabot.result }}" == "failure" && "${{ matrix.label }}" == "dependabot" ]]; then
 
             # Enable the steps to run
@@ -436,8 +466,8 @@ jobs:
             # Set the issue title
             if [[ "${{ matrix.label }}" == "govulncheck" ]]; then
               ISSUE_TITLE="Go Vulnerability Report"
-            elif [[ "${{ matrix.label }}" == "trivy" ]]; then
-              ISSUE_TITLE="Trivy Vulnerability Report"
+            elif [[ "${{ matrix.label }}" == "grype" ]]; then
+              ISSUE_TITLE="Grype Vulnerability Report"
             elif [[ "${{ matrix.label }}" == "dependabot" ]]; then
               ISSUE_TITLE="Dependabot Security Alerts"
             fi
@@ -544,8 +574,8 @@ jobs:
   slack_notification:
     name: Send Slack notification for failed jobs
     runs-on: ${{ inputs.runs-on }}
-    needs: [govulncheck, trivy, create_issues, dependabot]
-    if: always() && (needs.govulncheck.result == 'failure' || needs.trivy.result == 'failure' || needs.dependabot.result == 'failure')
+    needs: [govulncheck, grype, create_issues, dependabot]
+    if: always() && (needs.govulncheck.result == 'failure' || needs.grype.result == 'failure' || needs.dependabot.result == 'failure')
     steps:
       - name: Download govulncheck issue artifact
         if: needs.govulncheck.result == 'failure'
@@ -554,11 +584,11 @@ jobs:
           name: govulncheck-issue
         continue-on-error: true # Continue if the artifact is not found
 
-      - name: Download trivy issue artifact
-        if: inputs.execute-trivy-scan && needs.trivy.result == 'failure'
+      - name: Download grype issue artifact
+        if: (inputs.execute-grype-scan || inputs.execute-trivy-scan) && needs.grype.result == 'failure'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: trivy-issue
+          name: grype-issue
         continue-on-error: true # Continue if the artifact is not found
 
       - name: Download dependabot issue artifact
@@ -576,17 +606,17 @@ jobs:
             MESSAGE="$MESSAGE
             - $(cat govulncheck-issue.txt)"
           fi
-          if [ -f trivy-issue.txt ]; then
+          if [ -f grype-issue.txt ]; then
             MESSAGE="$MESSAGE
-            - $(cat trivy-issue.txt)"
+            - $(cat grype-issue.txt)"
           fi
           if [ -f dependabot-issue.txt ]; then
             MESSAGE="$MESSAGE
             - $(cat dependabot-issue.txt)"
           fi
-          echo 'SLACK_MESSAGE<<EOF' >> $GITHUB_ENV
-          echo "$MESSAGE" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          echo 'slack_message<<EOF' >> $GITHUB_OUTPUT
+          echo "$MESSAGE" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
       - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
@@ -594,4 +624,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ inputs.slack-channel-id || secrets.SLACK_CHANNEL_ID }}
-            text: ${{ toJSON(env.SLACK_MESSAGE) }}
+            text: ${{ toJSON(steps.prepare_message.outputs.slack_message) }}

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -318,10 +318,9 @@ jobs:
           echo "BUILD_ARGS=$build_args" >> $GITHUB_ENV
 
       - name: Build docker image
-        id: build-image
         run: |
           repo_name=$(echo "${{ github.repository }}" | awk '{print tolower($0)}')
-          echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$repo_name" >> $GITHUB_ENV
 
           docker_files="${{ inputs.docker-build-files }}"
           # Trim the '[]' and '"' characters from the array
@@ -343,7 +342,7 @@ jobs:
         id: grype_scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image: '${{ steps.build-image.outputs.repo_name }}:latest'
+          image: '${{ env.REPO_NAME }}:latest'
           fail-build: 'true'
           severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
           output-format: 'table'
@@ -355,7 +354,7 @@ jobs:
         if: inputs.upload-sarif
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image: '${{ steps.build-image.outputs.repo_name }}:latest'
+          image: '${{ env.REPO_NAME }}:latest'
           fail-build: 'false'
           severity-cutoff: '${{ inputs.grype-fail-on-severity }}'
           output-format: 'sarif'

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -35,7 +35,6 @@ on:
         type: string
         default: 'high'
         description: Minimum vulnerability severity that causes Grype to fail the build (negligible, low, medium, high, critical)
-
       execute-dependabot-check:
         required: false
         type: boolean
@@ -87,6 +86,11 @@ on:
         type: string
         default: 'auto'
         description: 'Semgrep configuration to use (auto, p/security-audit, p/owasp-top-ten, etc.)'
+      semgrep-max-target-bytes:
+        required: false
+        type: number
+        default: 500000
+        description: 'Skip scanning files larger than this size (in bytes)'
 
       runs-on:
         required: false
@@ -273,11 +277,11 @@ jobs:
       - name: Perform Semgrep Analysis and Generate SARIF
         if: inputs.upload-sarif
         run: |
-          semgrep scan --config ${{ inputs.semgrep-config }} --max-target-bytes 500000 --sarif > semgrep.sarif
+          semgrep scan --config ${{ inputs.semgrep-config }} --max-target-bytes ${{ inputs.semgrep-max-target-bytes }} --sarif > semgrep.sarif
       - name: Perform Semgrep Analysis with CLI Output
         if: ${{ !inputs.upload-sarif }}
         run: |
-          semgrep scan --config ${{ inputs.semgrep-config }} --max-target-bytes 500000
+          semgrep scan --config ${{ inputs.semgrep-config }} --max-target-bytes ${{ inputs.semgrep-max-target-bytes }}
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: inputs.upload-sarif
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/golang-security-scan.yml
+++ b/.github/workflows/golang-security-scan.yml
@@ -273,11 +273,11 @@ jobs:
       - name: Perform Semgrep Analysis and Generate SARIF
         if: inputs.upload-sarif
         run: |
-          semgrep scan --config ${{ inputs.semgrep-config }} --sarif > semgrep.sarif
+          semgrep scan --config ${{ inputs.semgrep-config }} --max-target-bytes 500000 --sarif > semgrep.sarif
       - name: Perform Semgrep Analysis with CLI Output
         if: ${{ !inputs.upload-sarif }}
         run: |
-          semgrep scan --config ${{ inputs.semgrep-config }}
+          semgrep scan --config ${{ inputs.semgrep-config }} --max-target-bytes 500000
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: inputs.upload-sarif
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,9 +18,12 @@ on:
         default: '.release-please-manifest.json'
         description: Path to the release-please manifest file
     secrets:
+      RELEASE_PLEASE_APP_CLIENT_ID:
+        required: false
+        description: GitHub App Client ID for authentication
       RELEASE_PLEASE_APP_ID:
-        required: true
-        description: GitHub App ID for authentication
+        required: false
+        description: '[DEPRECATED] Use RELEASE_PLEASE_APP_CLIENT_ID. Kept for backward compatibility.'
       RELEASE_PLEASE_APP_PEM:
         required: true
         description: GitHub App private key for authentication
@@ -38,7 +41,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID || secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PEM }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -60,9 +60,12 @@ on:
         type: string
         default: ''
     secrets:
+      app_client_id:
+        description: GitHub App Client ID for authentication
+        required: false
       app_id:
-        description: GitHub App ID for authentication
-        required: true
+        description: '[DEPRECATED] Use app_client_id. Kept for backward compatibility.'
+        required: false
       app_pem:
         description: GitHub App private key for authentication
         required: true
@@ -102,7 +105,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.app_client_id || secrets.app_id }}
           private-key: ${{ secrets.app_pem }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -185,7 +188,6 @@ jobs:
           git-push: ${{ inputs.git_push }}
           git-push-user-name: github-actions[bot]
           git-push-user-email: github-actions[bot]@users.noreply.github.com
-          git-push-token: ${{ steps.app-token.outputs.token }}
 
   detect-changed-dirs:
     name: Detect Changed Terraform Directories

--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -77,9 +77,15 @@ jobs:
           quiet: true
           soft_fail: true
 
-      - name: Upload SARIF file
+      - name: Filter Checkov SARIF results with inline suppressions
         if: hashFiles('results.sarif') != ''
+        run: |
+          jq 'del(.runs[].results[] | select(.suppressions != null))' \
+            results.sarif > results-filtered.sarif
+
+      - name: Upload SARIF file
+        if: hashFiles('results-filtered.sarif') != ''
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
-          sarif_file: results.sarif
+          sarif_file: results-filtered.sarif
           category: checkov


### PR DESCRIPTION
## Summary

- Add SARIF upload support across the Go workflow templates (govulncheck, golangci-lint, semgrep) so findings show up in GitHub Advanced Security's Code Scanning dashboard, alongside the existing GitHub Issue / Slack alerting.
- Add Semgrep SAST scanning to both `golang-ci.yml` (PR-triggered, diff-aware) and `golang-security-scan.yml` (scheduled, full-repo).
- Replace Trivy with Grype as the Docker image vulnerability scanner. `execute-trivy-scan` is removed entirely (not kept as an alias) from both `golang-security-scan.yml` and `docker-build-and-scan.yml` — see ⚠ Breaking Changes below.
- Fix Checkov SARIF uploads (`terraform-security-scan.yml`) so inline `checkov:skip` suppressions are actually filtered out before reaching Code Scanning.
- Migrate GitHub App authentication (`release-please.yml`, `terraform-ci.yml`) from `app-id` to `client-id`, keeping the old secret as a deprecated fallback.

## ⚠ Breaking Changes

- **`golang-security-scan.yml`**: `execute-trivy-scan` input removed. Any caller still passing it (`true` or `false`) will fail with an "Unexpected input(s)" error and must delete the line, switching to `execute-grype-scan` if image scanning is needed.
- **`docker-build-and-scan.yml`**: same removal, same consequence for callers.
- In both cases, an audit of downstream consumer repos confirmed nobody sets `execute-trivy-scan: true`. A small number of callers explicitly pass `execute-trivy-scan: false`, which is functionally identical to leaving it unset — those will need a trivial one-line cleanup the next time they bump their pinned workflow version. None of them call this repo directly today (they go through a separately-maintained fork), so nothing breaks until that fork syncs a release containing this change.

## Changes by file

### `golang-ci.yml`
- New `upload-sarif` input: when set, `govulncheck` and `golangci-lint` emit and upload SARIF reports in addition to their existing pass/fail signal. Both reuse the same action-based invocation (`golang/govulncheck-action`, `golangci-lint-action`) for SARIF and non-SARIF modes via each tool's native output-format support, so enabling SARIF doesn't lose the actions' built-in caching or require a separate code path.
- New `semgrep-scan` job (matrixed per module-dir, `semgrep/semgrep` container). Uses `semgrep ci --baseline-commit=<merge-base-with-master>`, so PR runs are diff-aware — only findings introduced by the branch are analyzed/reported, instead of re-scanning the whole module on every push.
- New `semgrep-config` (default `auto`) and `semgrep-max-target-bytes` (default `500000`) inputs, so callers can tune ruleset breadth and skip oversized files.

### `golang-security-scan.yml`
- New `execute-semgrep-scan` input and `semgrep_scan` job — a full-repo scan (not diff-aware, since this is the scheduled posture scan, not a PR check). Requires `actions: read` alongside the existing permissions, needed by the SARIF upload step.
- New `semgrep-config` (default `auto`) and `semgrep-max-target-bytes` (default `500000`) inputs; `--max-target-bytes` applied to both semgrep invocations to skip large non-source files.
- `execute-trivy-scan` removed entirely — see ⚠ Breaking Changes above.

### `terraform-security-scan.yml`
- Filter Checkov's SARIF output to drop any result carrying a `suppressions` property before uploading. Checkov marks inline `# checkov:skip=...` suppressions with `suppressions: [{"kind": "inSource", ...}]` in its SARIF output, but still emits the result at `level: warning` — and GitHub Code Scanning's supported SARIF properties for third-party tool uploads don't include `suppressions` (that's only honored for CodeQL's own native results). The net effect was every inline-suppressed Checkov finding showing up as an open alert on the Code Scanning dashboard despite being explicitly skipped in the repo. Mirrors the existing TFLint SARIF-filtering step in the same job.

### `docker-build-and-scan.yml`
- Remove Trivy scanning entirely in favor of Grype, including the `execute-trivy-scan` input itself — see ⚠ Breaking Changes above.

### `release-please.yml` / `terraform-ci.yml`
- Migrate GitHub App token generation from `app-id` to `client-id` (per `actions/create-github-app-token` v3), keeping the old app-id secret as a deprecated fallback for backward compatibility.

## Testing

All changes have been validated against real consumers — see PR comments for the specific validation runs and links (`terraform-ci.yml`, `release-please.yml`, `golang-ci.yml`, `golang-security-scan.yml`). All SARIF/Semgrep additions are opt-in, so existing callers are zero-impact.
